### PR TITLE
Fix typo

### DIFF
--- a/content/05.main-text.md
+++ b/content/05.main-text.md
@@ -408,7 +408,7 @@ This approach could take scores for human genes and convert them to side effects
 
 Our work is not without limitation.
 The final product relies on multiple databases and cached computations that specific to Hetionet v1.0.
-Despite sriving for a modular architecture,
+Despite striving for a modular architecture,
 generating an equivalent search webapp for a different hetnet would be challenging due to the many components involved.
 Furthermore, we would benefit from greater real-world evaluation of the connectivity search results to help identify situations where the method underperforms.
 Despite these challenges, our study demonstrates one of the first public search engines for node connectivity on a biomedical knowledge graph, while contributing methods and software that we hope will inspire future work.


### PR DESCRIPTION
As I was reading through the paper, I noticed that "striving" was missing a 't'. This PR fixes that